### PR TITLE
Fixed abs' header and invocation

### DIFF
--- a/src/infopanel.cpp
+++ b/src/infopanel.cpp
@@ -17,6 +17,7 @@
 
 #include <string.h>
 #include <algorithm>
+#include <cmath>
 #include "kclog.h"
 #include "infopanel.h"
 #include "net.h"
@@ -90,14 +91,14 @@ void InfoPanel::refresh()
     bool compact = true; //компактный вывод статистики если user=host
     int line,col;
     getyx(win,line,col);
-    if ( (!compact)||(abs(usertotal - hosttotal) > 1) )
+    if ( (!compact)||(std::abs(usertotal - hosttotal) > 1) )
     {
 	mvwprintw(win,line++,0,"user total%10.0f\n",usertotal);
 	mvwprintw(win,line++,0,"host total%10.0f\n",hosttotal);
     }
     else
 	mvwprintw(win,line++,0,"total     %10.0f\n",usertotal);
-    if ( (!compact)||(abs(useravg - hostavg) > 1) )
+    if ( (!compact)||(std::abs(useravg - hostavg) > 1) )
     {
 	mvwprintw(win,line++,0,"user avg  %10.0f\n",useravg);
 	mvwprintw(win,line++,0,"host avg  %10.0f\n",hostavg);
@@ -109,7 +110,7 @@ void InfoPanel::refresh()
     strftime(buf, sizeof(buf),"%-e %b",ltime); //"%-e %b %-k:%M"
     mvwprintw(win,line++,0,"%-s %s\n", buf, getdayname(laststattime).c_str()); //дата/время последней статистики
     //wattrset(win,0);
-    if ( (!compact)||(abs(lastdayuser - lastdayhost) > 1) )
+    if ( (!compact)||(std::abs(lastdayuser - lastdayhost) > 1) )
     {
 	if ( asciilinedraw == 1)
 	{
@@ -141,11 +142,11 @@ void InfoPanel::refresh()
 	int needlines = 2;
 	if (!projects[i].sstatus.empty())
 	    needlines++;
-	if ( (!compact)||(abs(projects[i].user - projects[i].host) > 1) )
+	if ( (!compact)||(std::abs(projects[i].user - projects[i].host) > 1) )
 	    needlines += 2;
 	else
 	    needlines++;
-	if ( (!compact)||(abs(projects[i].userlastday - projects[i].hostlastday) > 1) )
+	if ( (!compact)||(std::abs(projects[i].userlastday - projects[i].hostlastday) > 1) )
 	    needlines += 2;
 	else
 	    needlines++;
@@ -161,7 +162,7 @@ void InfoPanel::refresh()
 	    mvwprintw(win,line++,0,"%s\n",projects[i].sstatus.c_str());
 	}
 	wattrset(win,getcolorpair(COLOR_WHITE,COLOR_BLACK));
-	if ( (!compact)||(abs(projects[i].user - projects[i].host) > 1) )
+	if ( (!compact)||(std::abs(projects[i].user - projects[i].host) > 1) )
 	{
 	    mvwprintw(win,line++,0,"user total%10.0f\n",projects[i].user);
 	    mvwprintw(win,line++,0,"host total%10.0f\n",projects[i].host);
@@ -171,7 +172,7 @@ void InfoPanel::refresh()
 	ltime = localtime(&projects[i].laststattime);
 	strftime(buf, sizeof(buf),"%-e %b",ltime); //"%-e %b %-k:%M"
 	mvwprintw(win,line++,0,"%-s %s\n",buf, getdayname(projects[i].laststattime).c_str());
-	if ( (!compact)||(abs(projects[i].userlastday - projects[i].hostlastday) > 1) )
+	if ( (!compact)||(std::abs(projects[i].userlastday - projects[i].hostlastday) > 1) )
 	{
 	    if (asciilinedraw == 1)
 	    {

--- a/src/nmessagebox.cpp
+++ b/src/nmessagebox.cpp
@@ -17,7 +17,7 @@
 
 #include <string.h>
 #include <algorithm>
-#include <math.h>
+#include <cmath>
 #include "kclog.h"
 #include "nmessagebox.h"
 
@@ -172,4 +172,3 @@ void NMessageBox::eventhandle(NEvent* ev) 	//обработчик событий
 	    ev->done = true;
     }
 }
-

--- a/src/nscrollbar.cpp
+++ b/src/nscrollbar.cpp
@@ -16,7 +16,7 @@
 // =============================================================================
 
 
-#include <math.h>
+#include <cmath>
 #include "nscrollbar.h"
 #include "kclog.h"
 


### PR DESCRIPTION
It is advisable to use `<cmath>` instead of `<math.h>` so as to avoid overload ambiguity errors.
