### PR TITLE
Add 'M' as an alternative for opening the menu

### DIFF
--- a/src/helpwin.cpp
+++ b/src/helpwin.cpp
@@ -38,7 +38,7 @@ HelpWin::HelpWin(int rows, int cols) : NGroup(NRect(rows, cols, getmaxy(stdscr)/
     text1->appendstring(attr2,"       \"N\"           - Toogle between BOINC hosts\n");
     text1->appendstring(attr2,"       \"C\"           - Edit configuration\n");
     text1->appendstring(attr2,"       \"Q\"           - Quit boinctui\n");
-    text1->appendstring(attr2,"       \"F9\"          - Toogle main menu\n");
+    text1->appendstring(attr2,"       \"F9\"/\"M\"      - Toogle main menu\n");
     text1->appendstring(attr2,"       \"PgUp\"/\"PgDn\" - Scroll Messages Window\n");
     text1->appendstring(attr2,"\n");
     text1->appendstring(attr1,"   Task Controls:\n");

--- a/src/mainprog.cpp
+++ b/src/mainprog.cpp
@@ -132,7 +132,7 @@ void MainProg::updatestatuslinecontent()
 	    wstatus->appendstring(attrBG, " Enter Info");
 	}
 	wstatus->appendstring(attrWG, " |");
-	wstatus->appendstring(attrYG, " F9");
+	wstatus->appendstring(attrYG, " F9/M");
 	wstatus->appendstring(attrWG, " Menu |");
 	wstatus->appendstring(attrYG, " V");
 	wstatus->appendstring(attrWG, " Statistics |");
@@ -237,6 +237,8 @@ void MainProg::eventhandle(NEvent* ev)	//обработчик событий К�
 		uistate = uistate & ~stUIMODALFORM;
 		updatestatuslinecontent();
 		break;
+	    case 'M':
+	    case 'm':
 	    case KEY_F(9):
 		if (!menu->isenable())
 		{


### PR DESCRIPTION
Sometimes the F9 key is bound to other purposes (In my case byobu.).
Add 'm' as an alternative.

Signed-off-by: Erik Zeek <zeekec@gmail.com>