### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,13 @@
+boinctui (2.7.0-2) UNRELEASED; urgency=medium
+
+  * Trim trailing whitespace.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Wed, 07 Sep 2022 17:19:42 -0000
+
 boinctui (2.7.0-1) unstable; urgency=low
 
   * command line parameters "--boinchost" and "--pwd"
-  
+
   * fix build with autoconf 2.7.1
 
  -- Sergey Suslov <suleman1971@gmail.com>  Thu, 05 May 2022 17:00:00 +0300

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ boinctui (2.7.0-2) UNRELEASED; urgency=medium
 
   * Trim trailing whitespace.
   * Bump debhelper from old 11 to 13.
+  * Set upstream metadata fields: Archive.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 07 Sep 2022 17:19:42 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ boinctui (2.7.0-2) UNRELEASED; urgency=medium
   * Trim trailing whitespace.
   * Bump debhelper from old 11 to 13.
   * Set upstream metadata fields: Archive.
+  * Fix day-of-week for changelog entry 2.6.0-1.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 07 Sep 2022 17:19:42 -0000
 
@@ -23,7 +24,7 @@ boinctui (2.6.0-1) unstable; urgency=low
     transparent background, "receive time" and "swap size" columns in task window,
     host's label in task window, etc.
 
- -- Sergey Suslov <suleman1971@gmail.com>  Sat, 19 Nov 2021 16:00:00 +0300
+ -- Sergey Suslov <suleman1971@gmail.com>  Fri, 19 Nov 2021 16:00:00 +0300
 
 
 boinctui (2.5.2-1) unstable; urgency=low

--- a/debian/changelog
+++ b/debian/changelog
@@ -5,6 +5,7 @@ boinctui (2.7.0-2) UNRELEASED; urgency=medium
   * Set upstream metadata fields: Archive.
   * Fix day-of-week for changelog entry 2.6.0-1.
   * Update standards version to 4.6.1, no changes needed.
+  * Update standards version to 4.6.2, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 07 Sep 2022 17:19:42 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 boinctui (2.7.0-2) UNRELEASED; urgency=medium
 
   * Trim trailing whitespace.
+  * Bump debhelper from old 11 to 13.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 07 Sep 2022 17:19:42 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,7 @@ boinctui (2.7.0-2) UNRELEASED; urgency=medium
   * Bump debhelper from old 11 to 13.
   * Set upstream metadata fields: Archive.
   * Fix day-of-week for changelog entry 2.6.0-1.
+  * Update standards version to 4.6.1, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 07 Sep 2022 17:19:42 -0000
 

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Sergey Suslov <suleman1971@gmail.com>
 Build-Depends: autoconf, debhelper (>= 9), debhelper-compat (= 13),
  libncursesw5-dev, libgnutls-openssl-dev, libexpat1-dev
-Standards-Version: 4.6.1
+Standards-Version: 4.6.2
 Vcs-Git: https://github.com/suleman1971/boinctui.git
 Vcs-Browser: https://github.com/suleman1971/boinctui
 Homepage: https://github.com/suleman1971/boinctui

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Sergey Suslov <suleman1971@gmail.com>
 Build-Depends: autoconf, debhelper (>= 9), debhelper-compat (= 13),
  libncursesw5-dev, libgnutls-openssl-dev, libexpat1-dev
-Standards-Version: 4.5.0
+Standards-Version: 4.6.1
 Vcs-Git: https://github.com/suleman1971/boinctui.git
 Vcs-Browser: https://github.com/suleman1971/boinctui
 Homepage: https://github.com/suleman1971/boinctui

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: boinctui
 Section: net
 Priority: optional
 Maintainer: Sergey Suslov <suleman1971@gmail.com>
-Build-Depends: autoconf, debhelper (>= 9), debhelper-compat (= 11),
+Build-Depends: autoconf, debhelper (>= 9), debhelper-compat (= 13),
  libncursesw5-dev, libgnutls-openssl-dev, libexpat1-dev
 Standards-Version: 4.5.0
 Vcs-Git: https://github.com/suleman1971/boinctui.git

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,3 +1,4 @@
+Archive: SourceForge
 Bug-Database: https://github.com/suleman1971/boinctui/issues
 Bug-Submit: https://github.com/suleman1971/boinctui/issues/new
 Repository: https://github.com/suleman1971/boinctui.git


### PR DESCRIPTION
Fix some issues reported by lintian

* Trim trailing whitespace. ([trailing-whitespace](https://lintian.debian.org/tags/trailing-whitespace))
* Bump debhelper from old 11 to 13. ([package-uses-old-debhelper-compat-version](https://lintian.debian.org/tags/package-uses-old-debhelper-compat-version))
* Set upstream metadata fields: Archive.
* Fix day-of-week for changelog entry 2.6.0-1. ([debian-changelog-has-wrong-day-of-week](https://lintian.debian.org/tags/debian-changelog-has-wrong-day-of-week))
* Update standards version to 4.6.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))
* Update standards version to 4.6.2, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))

## Debdiff

These changes affect the binary packages:

[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/34/d01e114def0808bd5cb5641c3600f8f99258da.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/be/175b1ae276fdf389b9116d044c4629b81bbf4a.debug
### Control files of package boinctui: lines which differ (wdiff format)
* Depends: libc6 (>= [-2.33),-] {+2.34),+} libexpat1 (>= 2.0.1), libgcc-s1 (>= 3.0), libgnutls-openssl27 (>= 3.7.0), libncursesw6 (>= 6), libstdc++6 (>= 11), libtinfo6 (>= 6)
### Control files of package boinctui-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-be175b1ae276fdf389b9116d044c4629b81bbf4a-] {+34d01e114def0808bd5cb5641c3600f8f99258da+}

You can also view the [diffoscope diff](https://janitor.debian.net/api/run/670258c3-da2d-442f-bdd9-bfb06e07aef7/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/670258c3-da2d-442f-bdd9-bfb06e07aef7/diffoscope)).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/lintian-fixes), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/lintian-fixes/pkg/boinctui/670258c3-da2d-442f-bdd9-bfb06e07aef7.