### PR TITLE
Alpine Docker Container Image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM alpine AS base
+
+RUN \
+    apk add \
+        automake autoconf g++ make \
+        ncurses-dev expat-dev openssl-dev
+
+COPY ./ /workdir/
+WORKDIR /workdir
+
+RUN \
+    autoconf; \
+    automake --add-missing; \
+    ./configure --without-gnutls; \
+    make; \
+    strip boinctui
+
+FROM alpine AS final
+
+RUN \
+    apk add --no-cache \
+        expat ncurses openssl libstdc++ \
+        libpanelw libformw libmenuw
+
+COPY --from=base /workdir/boinctui /
+ENTRYPOINT ["/boinctui"]


### PR DESCRIPTION
Minimal two-step docker container image build with Alpine Linux.

Can be build with

```
docker build --progress=plain -t boinctui .
```

Runnable with config passthrough:

```
docker run -it --rm -v $HOME/.boinctui.cfg:/root/.boinctui.cfg boinctui
```